### PR TITLE
Add CNAME to static folder

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+idetools.dev


### PR DESCRIPTION
Prevents CNAME from being deleted when GitHub Actions workflow is triggered.