### PR TITLE
Add description for vscode-xml

### DIFF
--- a/docs/languages/vscode-xml.md
+++ b/docs/languages/vscode-xml.md
@@ -4,4 +4,17 @@ sidebar_position: 3
 
 # VS Code XML
 
+[![Link to GitHub](https://img.shields.io/badge/GitHub-redhat%E2%80%93developer%2Fvscode%E2%80%93xml-GitHub?style=for-the-badge&logo=github&logoColor=white&color=black)](https://github.com/redhat-developer/vscode-xml)
+[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/redhat.vscode-xml?color=informational&logo=visualstudiocode&style=for-the-badge&label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml)
+[![Installs](https://img.shields.io/visual-studio-marketplace/i/redhat.vscode-xml?logo=visualstudiocode&color=informational&style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml)
+[![Join the chat at https://gitter.im/redhat-developer/vscode-xml](https://img.shields.io/gitter/room/redhat-developer/vscode-xml?color=ED0060&style=for-the-badge&logo=gitter)](https://gitter.im/redhat-developer/vscode-xml?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+This VS Code extension provides support for creating and editing XML documents, based on the [LemMinX XML Language Server](https://github.com/eclipse/lemminx).
+
+<img src="https://user-images.githubusercontent.com/148698/45977901-df208a80-c018-11e8-85ec-71c70ba8a5ca.gif" width="100%" alt="GIF showing the basic features of vscode-xml being used in VS Code" />
+
+It supports syntax validation, formatting, and tag auto closing.
+It also supports schema-based validation using XSD, DTD, and RelaxNG schemas.
+For a full list of features, please check out the GitHub README.
+
 [Visit the GitHub](https://github.com/redhat-developer/vscode-xml)


### PR DESCRIPTION
I've kept the description short to avoid duplicating what's in the GitHub README, so that we don't need to keep the complete list of features on both the GitHub README and this page up to date.

Closes #42

Signed-off-by: David Thompson <davthomp@redhat.com>
